### PR TITLE
add e621 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,32 +99,32 @@ leave the test environment untouched so you can investigate the error.
 
 ## Site support
 
-| Site                                    | Anchor exporter | Subscriptions, single URL downloads | Test |
-|-----------------------------------------| --------------- | ----------------------------------- | ---- |
-| pixiv                                   | yes | yes | yes |
-| gelbooru                                | yes | yes | yes |
-| danbooru                                | yes | yes | yes |
-| lolibooru.moe                           | yes | yes | yes |
-| 3dbooru                                 | yes | yes | yes |
-| artstation                              | yes | yes | yes |
-| sankaku                                 | yes | yes | yes |
-| idolcomplex                             | yes | yes | yes |
-| twitter                                 | yes | yes | yes |
-| deviantart                              | yes | yes | yes |
-| patreon                                 | no | yes | yes |
-| nijie                                   | yes | yes | yes |
-| tumblr                                  | yes | yes | no |
-| fantia                                  | no | yes | no |
-| fanbox                                  | no | yes | no |
-| webtoons                                | no | yes | yes |
-| kemono.party                            | no | yes | no |
-| seiso.party                             | no | yes | no |
-| baraag                                  | no | yes | yes |
-| pawoo                                   | no | yes | yes |
-| hentaifoundry                           | yes | yes | yes |
-| yande.re                                | yes | yes | yes |
-| rule34.xxx                              | yes | yes | yes |
- | e621.net                                | yes | yes | yes |
+| Site | Anchor exporter | Subscriptions, single URL downloads | Test |
+| ---- | --------------- | ----------------------------------- | ---- |
+| pixiv | yes | yes | yes |
+| gelbooru | yes | yes | yes |
+| danbooru | yes | yes | yes |
+| lolibooru.moe | yes | yes | yes |
+| 3dbooru | yes | yes | yes |
+| artstation | yes | yes | yes |
+| sankaku | yes | yes | yes |
+| idolcomplex | yes | yes | yes |
+| twitter | yes | yes | yes |
+| deviantart | yes | yes | yes |
+| patreon | no | yes | yes |
+| nijie | yes | yes | yes |
+| tumblr | yes | yes | no |
+| fantia | no | yes | no |
+| fanbox | no | yes | no |
+| webtoons | no | yes | yes |
+| kemono.party | no | yes | no |
+| seiso.party | no | yes | no |
+| baraag | no | yes | yes |
+| pawoo | no | yes | yes |
+| hentaifoundry | yes | yes | yes |
+| yande.re | yes | yes | yes |
+| rule34.xxx | yes | yes | yes |
+| e621.net | yes | yes | yes |
 | any other site that gallery-dl supports | no | mostly* | no |
 
 *Downloading works, automatically getting subscription info from URLs and checking file download status through API from the anchor database does not.

--- a/README.md
+++ b/README.md
@@ -99,31 +99,32 @@ leave the test environment untouched so you can investigate the error.
 
 ## Site support
 
-| Site | Anchor exporter | Subscriptions, single URL downloads | Test |
-| ---- | --------------- | ----------------------------------- | ---- |
-| pixiv | yes | yes | yes |
-| gelbooru | yes | yes | yes |
-| danbooru | yes | yes | yes |
-| lolibooru.moe | yes | yes | yes |
-| 3dbooru | yes | yes | yes |
-| artstation | yes | yes | yes |
-| sankaku | yes | yes | yes |
-| idolcomplex | yes | yes | yes |
-| twitter | yes | yes | yes |
-| deviantart | yes | yes | yes |
-| patreon | no | yes | yes |
-| nijie | yes | yes | yes |
-| tumblr | yes | yes | no |
-| fantia | no | yes | no |
-| fanbox | no | yes | no |
-| webtoons | no | yes | yes |
-| kemono.party | no | yes | no |
-| seiso.party | no | yes | no |
-| baraag | no | yes | yes |
-| pawoo | no | yes | yes |
-| hentaifoundry | yes | yes | yes |
-| yande.re | yes | yes | yes |
-| rule34.xxx | yes | yes | yes |
+| Site                                    | Anchor exporter | Subscriptions, single URL downloads | Test |
+|-----------------------------------------| --------------- | ----------------------------------- | ---- |
+| pixiv                                   | yes | yes | yes |
+| gelbooru                                | yes | yes | yes |
+| danbooru                                | yes | yes | yes |
+| lolibooru.moe                           | yes | yes | yes |
+| 3dbooru                                 | yes | yes | yes |
+| artstation                              | yes | yes | yes |
+| sankaku                                 | yes | yes | yes |
+| idolcomplex                             | yes | yes | yes |
+| twitter                                 | yes | yes | yes |
+| deviantart                              | yes | yes | yes |
+| patreon                                 | no | yes | yes |
+| nijie                                   | yes | yes | yes |
+| tumblr                                  | yes | yes | no |
+| fantia                                  | no | yes | no |
+| fanbox                                  | no | yes | no |
+| webtoons                                | no | yes | yes |
+| kemono.party                            | no | yes | no |
+| seiso.party                             | no | yes | no |
+| baraag                                  | no | yes | yes |
+| pawoo                                   | no | yes | yes |
+| hentaifoundry                           | yes | yes | yes |
+| yande.re                                | yes | yes | yes |
+| rule34.xxx                              | yes | yes | yes |
+ | e621.net                                | yes | yes | yes |
 | any other site that gallery-dl supports | no | mostly* | no |
 
 *Downloading works, automatically getting subscription info from URLs and checking file download status through API from the anchor database does not.

--- a/hydownloader/anchor_exporter.py
+++ b/hydownloader/anchor_exporter.py
@@ -120,7 +120,7 @@ def extract_reverse_lookup_data(hydrus_db_folder: str, save_folder: str):
 @cli.command(help='Add entries to an anchor database based on the URLs stored in a Hydrus database.')
 @click.option('--path', type=str, required=True, help='hydownloader database path.')
 @click.option('--hydrus-db-folder', type=str, required=True, help='Hydrus database directory (where the .db files are located).')
-@click.option('--sites', type=str, required=True, default='all', show_default=True, help='A comma-separated list of sites to add anchor entries for. Currently supported: pixiv, gelbooru, nijie, lolibooru, danbooru, 3dbooru, sankaku, idolcomplex, artstation, twitter, deviantart, tumblr, yandere, hentaifoundry, rule34. The special \'all\' value can be used to mean all supported sites (this is the default).')
+@click.option('--sites', type=str, required=True, default='all', show_default=True, help='A comma-separated list of sites to add anchor entries for. Currently supported: pixiv, gelbooru, nijie, lolibooru, danbooru, 3dbooru, sankaku, idolcomplex, artstation, twitter, deviantart, tumblr, yandere, hentaifoundry, rule34, e621. The special \'all\' value can be used to mean all supported sites (this is the default).')
 @click.option('--unrecognized-urls-file', type=str, required=False, default=None, show_default=True, help="Write URLs that are not recognized by the anchor generator but could be related to the listed sites into a separate file. You can check this file to see if there are any URLs that should have been used for generating anchors but weren't.")
 @click.option('--recognized-urls-file', type=str, required=False, default=None, show_default=True, help="Write URLs that were recognized by the anchor generator to this file.")
 @click.option('--fill-known-urls', type=bool, is_flag=True, required=False, default=False, show_default=True, help="Transfer all Hydrus URLs into the hydownloader database as known URLs.")
@@ -206,7 +206,8 @@ def update_anchor(path: str, hydrus_db_folder: str, sites: str, unrecognized_url
         'tumblr': (["tumblr"],[]),
         'hentaifoundry': (["hentai-foundry"],[]),
         'yandere': (["yande.re"],[]),
-        'rule34': (["rule34"],[])
+        'rule34': (["rule34"],[]),
+        'e621': (["e621"], [])
     }
 
     siteset = {x.strip() for x in sites.split(',') if x.strip()}

--- a/hydownloader/constants.py
+++ b/hydownloader/constants.py
@@ -1007,6 +1007,50 @@ DEFAULT_IMPORT_JOBS = """{
             ]
           }
         ]
+      },
+      {
+        "filter": "pstartswith(path, 'gallery-dl/e621/')",
+        "tagReposForNonUrlSources": ["my tags"],
+        "tags": [
+          {
+            "name": "e621 generated tags",
+            "allowEmpty": true,
+            "tagRepos": [
+              "my tags"
+            ],
+            "values": [
+              "'e621 id:' + str(json_data['id'])",
+              "'booru:e621'",
+              "'rating:' + json_data['rating']"
+            ]
+          },
+          {
+            "name": "e621 tags",
+            "allowTagsEndingWithColon": true,
+            "tagRepos": [
+              "my tags"
+            ],
+            "values": "get_nested_tags_e621(json_data['tags'])"
+          },
+          {
+            "name": "e621 post tags",
+            "allowTagsEndingWithColon": true,
+            "tagRepos": [
+              "my tags"
+            ],
+            "values": "get_nested_tags_e621(json_data['tags'])"
+          }
+        ],
+        "urls": [
+          {
+            "name": "e621 urls",
+            "allowEmpty": true,
+            "values": [
+              "json_data['gallerydl_file_url']",
+              "'https://e621.net/posts/' + str(json_data['id'])"
+            ]
+          }
+        ]
       }
     ]
   }
@@ -1625,6 +1669,10 @@ DEFAULT_GALLERY_DL_CONFIG = R"""{
         },
         
         "rule34": {
+            "archive-format": "{id}"
+        },
+        
+        "e621": {
             "archive-format": "{id}"
         }
     }

--- a/hydownloader/importer.py
+++ b/hydownloader/importer.py
@@ -72,6 +72,44 @@ def get_namespaces_tags(data: dict[str, Any], key_prefix : str = 'tags_', separa
             final_result.append(pair)
     return final_result
 
+# Get tags from a nested JSON entry
+# Example from 3621
+# {
+#     "tags": {
+#         "artist": [
+#             "artist_name"
+#         ],
+#         "character": [],
+#         "general": [
+#             "furry",
+#             "gay_furry",
+#             "straight_furry"
+#         ]
+#     }
+# }
+# data should be the tags entry like "json_data['tags']
+def get_nested_tags_e621(data: dict[str, Any]) -> list[str]:
+    tags = list[str]()
+    for namespace in data.items():
+        ns = namespace[0]
+        if ns == 'invalid':
+            #  e621 replaces tags they don't want with this or something like that, weird
+            pass
+        elif ns == 'general':
+            ns = ''
+        elif ns == 'artist':
+            ns = 'creator'
+        elif ns == 'copyright':
+            ns = 'series'
+
+        if ns != '':
+            ns = ns + ":"
+
+        for tag in namespace[1]:
+            tags.append(ns + tag.replace("_", " "))
+
+    return tags
+
 # Helper function to use in user-defined importer expressions
 def clean_url(url: str) -> str:
     return re.sub(r'(?<!:)//', '/', url)

--- a/hydownloader/importer.py
+++ b/hydownloader/importer.py
@@ -89,7 +89,7 @@ def get_namespaces_tags(data: dict[str, Any], key_prefix : str = 'tags_', separa
 # }
 # data should be the tags entry like "json_data['tags']
 def get_nested_tags_e621(data: dict[str, Any]) -> list[str]:
-    tags = list[str]()
+    tags: list[str] = []
     for namespace in data.items():
         ns = namespace[0]
         if ns == 'invalid':

--- a/hydownloader/tools.py
+++ b/hydownloader/tools.py
@@ -103,7 +103,7 @@ def check_results_of_post_url(data: dict, sitename: str) -> bool:
 
 @cli.command(help='Test downloading from a list of sites.')
 @click.option('--path', type=str, required=True, help='Database path.')
-@click.option('--sites', type=str, required=True, help='A comma-separated list of sites to test downloading from. Currently supported: environment, gelbooru, pixiv, lolibooru, patreon, danbooru, 3dbooru, nijie, sankaku, idolcomplex, artstation, twitter, deviantart, webtoons, baraag, pawoo, yandere, hentaifoundry, rule34. WARNING: this will attempt to download "sensitive" content.')
+@click.option('--sites', type=str, required=True, help='A comma-separated list of sites to test downloading from. Currently supported: environment, gelbooru, pixiv, lolibooru, patreon, danbooru, 3dbooru, nijie, sankaku, idolcomplex, artstation, twitter, deviantart, webtoons, baraag, pawoo, yandere, hentaifoundry, rule34, e621. WARNING: this will attempt to download "sensitive" content.')
 def test(path: str, sites: str) -> None:
     log.init(path, True)
     db.init(path)
@@ -276,6 +276,14 @@ def test_internal(sites: str) -> bool:
                 'rule34/rule34_4085100_230c488b6784beb15f0278f6a6ce2a93.jpg': [],
                 'rule34/rule34_4085100_230c488b6784beb15f0278f6a6ce2a93.jpg.json': ['"tags_artist": "methados"']
             }
+        },
+        'e621': {
+            'url': "https://e621.net/posts/1766367",
+            'anchors': ["e6211766367"],
+            'filenames': {
+                'e621/e621_1766367_441725945326e0fa7a3f21978cb38ded.jpg': [],
+                'e621/e621_1766367_441725945326e0fa7a3f21978cb38ded.jpg.json': ['"id": 1766367'],
+            }
         }
     }
 
@@ -410,6 +418,9 @@ def test_internal(sites: str) -> bool:
         elif site == "rule34":
             log.info("hydownloader-test", "Testing rule34.xxx...")
             should_break = not check_results_of_post_url(post_url_data['rule34'], site) or should_break
+        elif site == "e621":
+            log.info("hydownloader-test", "Testing e621.net...")
+            should_break = not check_results_of_post_url(post_url_data['e621'], site) or should_break
         else:
             log.error("hydownloader-test", f"Site name not recognized: {site}, no testing done")
             return False

--- a/hydownloader/urls.py
+++ b/hydownloader/urls.py
@@ -143,6 +143,8 @@ def subscription_data_to_url(downloader: str, keywords: str, allow_fail: bool = 
         return f"https://yande.re/post?tags={keywords}"
     if downloader == "rule34":
         return f"https://rule34.xxx/index.php?page=post&s=list&tags={keywords}"
+    if downloader == "e621":
+        return f"https://e621.net/posts?tags={keywords}"
 
     if not allow_fail:
         log.fatal("hydownloader", f"Invalid downloader: {downloader}")
@@ -215,6 +217,8 @@ def subscription_data_from_url(url: str) -> tuple[str, str]:
         return ('seisoparty', m.group('site')+"/"+m.group('id'))
     if m := re.match(r"https?://rule34\.xxx/index.php\?page=post&s=list&tags=(?P<keywords>[^&]+)(&.*)?", u):
         return ('rule34', m.group('keywords').lower())
+    if m := re.match(r"https?://e621\.net/posts\?tags=(?P<keywords>[^&]+)(&.*)?", u):
+        return ('e621', m.group('keywords').lower())
 
     return ('','')
 
@@ -245,6 +249,7 @@ def anchor_patterns_from_url(url: str) -> list[str]:
     fantia: {post_id}_{file_id}
     fanbox: {id}_{num} (num starts at 1)
     rule34.xxx: rule344085100
+    e621: e6211766367
     See also gallery-dl-config.json.
     """
     u = uri_normalizer.normalizes(url)
@@ -304,6 +309,8 @@ def anchor_patterns_from_url(url: str) -> list[str]:
         return [f"pawoo{m.group('id')}", f"pawoo{m.group('id')}_%"]
     if m := re.match(r"https?://rule34\.xxx/index\.php\?(page=post&)?(s=view&)?id=(?P<id>[0-9]+)(&.*)?", u):
         return [f"rule34{m.group('id')}"]
+    if m := re.match(r"https?://e621.net/posts/(?P<id>[0-9]+)(&.*)?", u):
+        return [f"e621{m.group('id')}"]
 
     return []
 


### PR DESCRIPTION
- Added `e621` as the downloader type
- Tested anchor exporting
- Tested file importing
- Tested single url and subscription
- Tested the test
- Specified the downloader in the test and anchor importer help
- Updated the readme
- __Added method in `importer.py` to parse e621 tags__