### PR TITLE
add coomer.party support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ leave the test environment untouched so you can investigate the error.
 | fanbox | no | yes | no |
 | webtoons | no | yes | yes |
 | kemono.party | no | yes | no |
+| coomer.party | no | yes | no |
 | seiso.party | no | yes | no |
 | baraag | no | yes | yes |
 | pawoo | no | yes | yes |

--- a/hydownloader/constants.py
+++ b/hydownloader/constants.py
@@ -625,6 +625,25 @@ DEFAULT_IMPORT_JOBS = """{
         ]
       },
       {
+        "filter": "pstartswith(path, 'gallery-dl/coomerparty/')",
+        "tagReposForNonUrlSources": ["my tags"],
+        "tags": [
+          {
+            "name": "coomerparty generated tags",
+            "tagRepos": [
+              "my tags"
+            ],
+            "values": [
+              "'title:'+json_data['title']",
+              "'person:'+json_data['username']",
+              "'coomer.party service:'+json_data['service']",
+              "'coomer.party id:'+json_data['id']",
+              "'coomer.party user id:'+json_data['user']"
+            ]
+          }
+        ]
+      },
+      {
         "filter": "pstartswith(path, 'gallery-dl/directlink/')",
         "tagReposForNonUrlSources": ["my tags"],
         "urls": [
@@ -1604,6 +1623,11 @@ DEFAULT_GALLERY_DL_CONFIG = R"""{
         },
 
         "kemonoparty": {
+            "filename": "{id}_{hash}_{type[0]}_{num}.{extension}",
+            "archive-format": "{service}_{user}_{id}_{filename}_{type[0]}.{extension}"
+        },
+        
+        "coomerparty": {
             "filename": "{id}_{hash}_{type[0]}_{num}.{extension}",
             "archive-format": "{service}_{user}_{id}_{filename}_{type[0]}.{extension}"
         },

--- a/hydownloader/urls.py
+++ b/hydownloader/urls.py
@@ -31,6 +31,7 @@ known_url_replacements = (
     ("&name=medium", "&name=orig"),
     ("&name=large", "&name=orig"),
     (r"(.*kemono\.party/.*)\?.*", "\\1"),
+    (r"(.*coomer\.party/.*)\?.*", "\\1"),
     (r"behoimi.org/post/show/([0-9]+)/.+", "behoimi.org/post/show/\\1"),
     (r"img[0-9].gelbooru.com", "img1.gelbooru.com"),
     (r"img[0-9].gelbooru.com", "img2.gelbooru.com"),
@@ -131,6 +132,11 @@ def subscription_data_to_url(downloader: str, keywords: str, allow_fail: bool = 
         return f"https://webtoons.com/{keywords}"
     if downloader == "kemonoparty":
         return f"https://kemono.party/{keywords}"
+    if downloader == "coomerparty":
+        # While coomer only supports onlyfans and this could be `/onlyfans/user/{keywords}`
+        # instead, it will be a massive pain for end users to edit their existing subs later
+        # if coomer adds other services.
+        return f"https://coomer.party/{keywords}"
     if downloader == "baraag":
         return f"https://baraag.net/@{keywords}"
     if downloader == "pawoo":
@@ -203,6 +209,8 @@ def subscription_data_from_url(url: str) -> tuple[str, str]:
         return ('webtoons', m.group('path'))
     if m := re.match(r"(?:https?://)?kemono\.party/(?P<service>[^/?#]+)/user/(?P<user>[^/?#]+)/?(?:$|[?#])", u):
         return ('kemonoparty', m.group('service')+"/user/"+m.group('user'))
+    if m := re.match(r"(?:https?://)?coomer\.party/(?P<service>[^/?#]+)/user/(?P<user>[^/?#]+)/?(?:$|[?#])", u):
+        return ('coomerparty', m.group('service')+"/user/"+m.group('user'))
     if m := re.match(r"https://baraag.net/@(?P<user>[^/?#]+)(?:/media)?/?$", u):
         return ('baraag', m.group('user'))
     if m := re.match(r"https://pawoo.net/@(?P<user>[^/?#]+)(?:/media)?/?$", u):


### PR DESCRIPTION
- Added `coomerparty` as the downloader type
- Tested file importing
- Tested single url and subscription
- Updated the readme
- -No test like kemono.party
- -No anchors like kemono.party
- Uses `person` namespace instead of `creator` for creator name.